### PR TITLE
CI: ignore LinkedIn anti-bot (999) in link-check

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Run lychee link checker
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --no-progress --verbose README.md README_DRAFT.md
+          args: --no-progress --verbose --accept 999 README.md README_DRAFT.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the link-check workflow to accept 999 status codes from LinkedIn, preventing false failures caused by LinkedIn's anti-bot protection mechanism.

**Changes:**
- Added `--accept 999` parameter to lychee link checker args
- This allows the workflow to pass when LinkedIn returns 999 status codes instead of treating them as failures

**Why this change is needed:**
LinkedIn returns 999 status codes as an anti-bot measure, which causes the link-check workflow to fail even though the LinkedIn links are valid and accessible to users.